### PR TITLE
chore(tweetPaginator): minor changes to v2.search and tweetPaginator

### DIFF
--- a/src/client.subclient.ts
+++ b/src/client.subclient.ts
@@ -23,11 +23,11 @@ export default abstract class TwitterApiSubClient extends TwitterApiBase {
     this._oauth = inst._oauth;
   }
 
-  public async get<T = any>(url: string, full_response?: boolean) : Promise<T | TwitterResponse<T>>;
-  public async get<T = any>(url: string, parameters?: Record<string, string | undefined>, full_response?: false, prefix?: string) : Promise<T>;
-  public async get<T = any>(url: string, parameters?: Record<string, string | undefined>, full_response?: true, prefix?: string) : Promise<TwitterResponse<T>>;
+  public async get<T = any>(url: string, full_response?: boolean) : Promise<T | TwitterResponse<T>>;
+  public async get<T = any>(url: string, parameters?: Record<string, string | number | undefined>, full_response?: false, prefix?: string) : Promise<T>;
+  public async get<T = any>(url: string, parameters?: Record<string, string | number | undefined>, full_response?: true, prefix?: string) : Promise<TwitterResponse<T>>;
 
-  public async get<T = any>(url: string, parameters?: Record<string, string | undefined> | boolean, full_response = false, prefix = this._prefix) : Promise<T | TwitterResponse<T>> {
+  public async get<T = any>(url: string, parameters?: Record<string, string | number | undefined> | boolean, full_response = false, prefix = this._prefix) : Promise<T | TwitterResponse<T>> {
     if (typeof parameters === 'boolean') {
       full_response = parameters;
       parameters = undefined;
@@ -38,11 +38,11 @@ export default abstract class TwitterApiSubClient extends TwitterApiBase {
   }
 
 
-  public async delete<T = any>(url: string, full_response?: boolean) : Promise<T | TwitterResponse<T>>;
-  public async delete<T = any>(url: string, parameters?: Record<string, string | undefined>, full_response?: false, prefix?: string) : Promise<T>;
-  public async delete<T = any>(url: string, parameters?: Record<string, string | undefined>, full_response?: true, prefix?: string) : Promise<TwitterResponse<T>>;
+  public async delete<T = any>(url: string, full_response?: boolean) : Promise<T | TwitterResponse<T>>;
+  public async delete<T = any>(url: string, parameters?: Record<string, string | number | undefined>, full_response?: false, prefix?: string) : Promise<T>;
+  public async delete<T = any>(url: string, parameters?: Record<string, string | number | undefined>, full_response?: true, prefix?: string) : Promise<TwitterResponse<T>>;
 
-  public async delete<T = any>(url: string, parameters?: Record<string, string | undefined> | boolean, full_response = false, prefix = this._prefix) : Promise<T | TwitterResponse<T>> {
+  public async delete<T = any>(url: string, parameters?: Record<string, string | number | undefined> | boolean, full_response = false, prefix = this._prefix) : Promise<T | TwitterResponse<T>> {
     if (typeof parameters === 'boolean') {
       full_response = parameters;
       parameters = undefined;

--- a/src/v2/client.v2.read.ts
+++ b/src/v2/client.v2.read.ts
@@ -9,14 +9,10 @@ import { Tweetv2SearchParams, Tweetv2SearchResult } from './types.v2';
 export default class TwitterApiv2ReadOnly extends TwitterApiSubClient {
   protected _prefix = API_V2_PREFIX;
 
-  public async search(what: string, options: Partial<Tweetv2SearchParams> = {}) {
-    options.query = what;
-    options.max_results = options.max_results ?? '10';
+  public async search(query: string, options: Partial<Tweetv2SearchParams> = {}) {
+    const queryParams = {...options, query};
+    const initialRq = await this.get<Tweetv2SearchResult>('tweets/search/recent', queryParams,true);
 
-    const initialRq = await this.get<Tweetv2SearchResult>('tweets/search/recent', options, true);
-
-    return new TweetPaginator(initialRq.data, initialRq.rateLimit!, this, {
-      query: options as Tweetv2SearchParams,
-    });
+    return new TweetPaginator(initialRq.data, initialRq.rateLimit!, this, queryParams);
   }
 }

--- a/src/v2/types.v2.ts
+++ b/src/v2/types.v2.ts
@@ -4,7 +4,7 @@ export interface Tweetv2SearchParams extends Partial<Tweetv2FieldsParams> {
   end_time?: string;
   /** ISO date string */
   start_time?: string;
-  max_results?: string;
+  max_results?: number | string;
   next_token?: string;
   query: string;
   since_id?: string;


### PR DESCRIPTION
Slightly refactor some things from @alkihis PR
- I don't thing there's a need for PaginatorParams (instead of just the search params)
- [style] use more decomposition, add brackets to if
- don't mutate the option object passed as parameter
- don't set the maxValue to 10, it's supposed to already be 10 and can change in the future (why would we force it)
- what = query, query/option=queryParams (otherwise it can be a bit confusing reading Twitter's doc)
- Add number as a possible queryParam value, set maxResult as number or string