### PR TITLE
chore(CI): Run tests in github workflow, leverage env variables

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 15.x]
+      max-parallel: 1 # the streaming API can be called only once at a time
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+        env:
+          CONSUMER_TOKEN: ${{ secrets.CONSUMER_TOKEN }}
+          CONSUMER_SECRET: ${{ secrets.CONSUMER_SECRET }}
+          OAUTH_TOKEN: ${{ secrets.OAUTH_TOKEN }}
+          OAUTH_SECRET: ${{ secrets.OAUTH_SECRET }}

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,8 +1,5 @@
 import { TwitterApi } from '..';
-import dotenv from 'dotenv';
 import { getAccessClient, getAppClient, getAuthLink } from './utils';
-
-const ENV = dotenv.config({ path: __dirname + '/../../.env' }).parsed!;
 
 (async () => {
   const argActive = (name: string) => process.argv.find(arg => arg.startsWith('--' + name));

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -1,25 +1,23 @@
 import { TwitterApi } from '..';
 import dotenv from 'dotenv';
 
-const ENV = dotenv.config({ path: __dirname + '/../../.env' }).parsed!;
-
-export const currentEnv = ENV as any;
+dotenv.config({ path: __dirname + '/../../.env' });
 
 /** User OAuth 1.0a client */
 export function getUserClient() {
   return new TwitterApi({
-    appKey: ENV.CONSUMER_TOKEN!,
-    appSecret: ENV.CONSUMER_SECRET!,
-    accessToken: ENV.OAUTH_TOKEN!,
-    accessSecret: ENV.OAUTH_SECRET!,
+    appKey: process.env.CONSUMER_TOKEN!,
+    appSecret: process.env.CONSUMER_SECRET!,
+    accessToken: process.env.OAUTH_TOKEN!,
+    accessSecret: process.env.OAUTH_SECRET!,
   });
 }
 
 // Test auth 1.0a flow
 export function getAuthLink(callback: string) {
   let requestClient = new TwitterApi({
-    appKey: ENV.CONSUMER_TOKEN!,
-    appSecret: ENV.CONSUMER_SECRET!,
+    appKey: process.env.CONSUMER_TOKEN!,
+    appSecret: process.env.CONSUMER_SECRET!,
   });
 
   return requestClient.generateAuthLink(callback);
@@ -27,10 +25,10 @@ export function getAuthLink(callback: string) {
 
 export async function getAccessClient(verifier: string) {
   let requestClient = new TwitterApi({
-    appKey: ENV.CONSUMER_TOKEN!,
-    appSecret: ENV.CONSUMER_SECRET!,
-    accessToken: ENV.OAUTH_TOKEN!,
-    accessSecret: ENV.OAUTH_SECRET!,
+    appKey: process.env.CONSUMER_TOKEN!,
+    appSecret: process.env.CONSUMER_SECRET!,
+    accessToken: process.env.OAUTH_TOKEN!,
+    accessSecret: process.env.OAUTH_SECRET!,
   });
 
   const { client } = await requestClient.login(verifier);
@@ -41,14 +39,14 @@ export async function getAccessClient(verifier: string) {
 export function getAppClient() {
   let requestClient: TwitterApi;
 
-  if (ENV.BEARER_TOKEN) {
-    requestClient = new TwitterApi(ENV.BEARER_TOKEN);
+  if (process.env.BEARER_TOKEN) {
+    requestClient = new TwitterApi(process.env.BEARER_TOKEN);
     return Promise.resolve(requestClient);
   }
   else {
     requestClient = new TwitterApi({
-      appKey: ENV.CONSUMER_TOKEN!,
-      appSecret: ENV.CONSUMER_SECRET!,
+      appKey: process.env.CONSUMER_TOKEN!,
+      appSecret: process.env.CONSUMER_SECRET!,
     });
     return requestClient.appLogin();
   }

--- a/test/auth.test.ts
+++ b/test/auth.test.ts
@@ -3,12 +3,12 @@ import { expect } from 'chai';
 import dotenv from 'dotenv';
 import { TwitterApi } from '../src';
 
-const ENV = dotenv.config({ path: __dirname + '/../.env' }).parsed!;
+dotenv.config({ path: __dirname + '/../.env' });
 
 // OAuth 1.0a
 const clientWithoutUser = new TwitterApi({
-  appKey: ENV.CONSUMER_TOKEN!,
-  appSecret: ENV.CONSUMER_SECRET!,
+  appKey: process.env.CONSUMER_TOKEN!,
+  appSecret: process.env.CONSUMER_SECRET!,
 });
 
 describe('Authentification API', () => {

--- a/test/stream.test.ts
+++ b/test/stream.test.ts
@@ -4,14 +4,14 @@ import dotenv from 'dotenv';
 import { TwitterApi, ETwitterStreamEvent } from '../src';
 import { getAppClient } from '../src/test/utils';
 
-const ENV = dotenv.config({ path: __dirname + '/../.env' }).parsed!;
+dotenv.config({ path: __dirname + '/../.env' });
 
 // OAuth 1.0a
 const clientOauth = new TwitterApi({
-  appKey: ENV.CONSUMER_TOKEN!,
-  appSecret: ENV.CONSUMER_SECRET!,
-  accessToken: ENV.OAUTH_TOKEN!,
-  accessSecret: ENV.OAUTH_SECRET!,
+  appKey: process.env.CONSUMER_TOKEN!,
+  appSecret: process.env.CONSUMER_SECRET!,
+  accessToken: process.env.OAUTH_TOKEN!,
+  accessSecret: process.env.OAUTH_SECRET!,
 });
 
 describe('Tweet stream API v1.1', () => {


### PR DESCRIPTION
Use process.env instead of leveraging only on the .env file

Runs npm test in the CI for node 14 and 15. One test fails on node 12, it will be added later.